### PR TITLE
Refactor to work with async and IPC

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,19 +6,19 @@
  */
 
 
-const { app, BrowserWindow } = require('electron')
-const {ipc}                  = require('electron')
-const { exec }               = require('child_process')
+const { app, BrowserWindow } = require('electron');
+const {ipc}                  = require('electron');
+const { exec }               = require('child_process');
 
-var fs = require('fs')
+var fs = require('fs');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected
-let win
+let win;
 
-var pipeline_args    = [{}]
-var pipeline_results = []
-var current_module   = 0
+var pipeline_args    = [{}];
+var pipeline_results = [];
+var current_module   = 0;
 
 
 function initial() {
@@ -26,11 +26,11 @@ function initial() {
      * Desc: Create the initial window, and set the close handler
      */
     // Create the browser window.
-    win = new BrowserWindow({width: 1024, height:768, backgroundColor: '#000'})
+    win = new BrowserWindow({width: 1024, height:768, backgroundColor: '#000'});
 
     // and load the index.html of the app.
-    win.loadURL('file:///'+ __dirname + '/module0.html')
-    console.log('loading module0.html')
+    win.loadURL('file:///'+ __dirname + '/module0.html');
+    console.log('loading module0.html');
 
     // Open the DevTools.
     //win.webContents.openDevTools()
@@ -40,8 +40,8 @@ function initial() {
         // Dereference the window object, usually you would store windows
         // in an array if your app supports multi windows, this is the time
         // when you should delete the corresponding element.
-        win = null
-    })
+        win = null;
+    });
 }
 
 
@@ -62,7 +62,7 @@ function goToModule(module_number) {
     }
     
     // Load the html
-    win.loadURL('file:///' + __dirname + '/module' + Integer.toString(module_number))
+    win.loadURL('file:///' + __dirname + '/module' + Integer.toString(module_number));
 
     return true;
 }
@@ -81,54 +81,54 @@ function execPipeline(cmd, args, callback) {
      *      - If pipeline returns an error string, return the error string
      *      - Else, return null
      */
-    args_json = JSON.parse(args)
+    args_json = JSON.parse(args);
    
-    pipeline_args[current_module] = args_json
+    pipeline_args[current_module] = args_json;
 
-    fs.writeFile(__dirname + 'args.json', args_json.toString())
+    fs.writeFile(__dirname + 'args.json', args_json.toString());
 
-    result = pipeline.pipeline(cmd, __dirname + 'args.json')
+    result = pipeline.pipeline(cmd, __dirname + 'args.json');
 
     child_process.exec(__dirname + '/lib/pipeline/' + cmd + 'args.json', (error, stdout, stderr) => {
         if(!stdout || stdout == '') {
-            callback(stdout)
+            callback(stdout);
 
         } else {
             // Read back in file
             fs.readFile(__dirname + 'args.json', 'utf-8', (err, data) => {
                 if(err) {
-                    console.log('Error reading json args file:', err)
-                    callback('Error reading json args file')
+                    console.log('Error reading json args file:', err);
+                    callback('Error reading json args file');
                 }
 
-                pipeline_results[current_module] = JSON.parse(result)
-                callback(null)
-            })
+                pipeline_results[current_module] = JSON.parse(result);
+                callback(null);
+            });
         }
-    })
+    });
 }
 
 
 /* CORE WINDOW EVENTS */
 
-app.on('ready', initial)
+app.on('ready', initial);
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   // On macOS it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
-    app.quit()
+    app.quit();
   }
-})
+});
 
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (win === null) {
-    initial()
+  if (win === null) {;
+    initial();
   }
-})
+});
 
 
 
@@ -138,9 +138,9 @@ app.on('activate', () => {
 ipc.on('LOADPAGE', (event, module_number) =>  {
     if(loadPage(data)) {
         // Send IPC message with the arguments to the current module
-        win.webContents.send('NEW', JSON.toString(pipeline_args[module_number]))
+        win.webContents.send('NEW', JSON.toString(pipeline_args[module_number]));
     }
-})
+});
 
 // Attempt to execute pipeline with args
 ipc.on('EXECUTE', (event, data) => {

--- a/main.js
+++ b/main.js
@@ -1,33 +1,117 @@
+/**
+ * Desc: Main file for controlling window rendering and backend pipeline communication.
+ *
+ * Authors:
+ *      - Chance Nelson <chance-nelson@nau.edu>
+ */
+
+
 const { app, BrowserWindow } = require('electron')
+const {ipc}                  = require('electron')
+const { exec }               = require('child_process')
+
+var fs = require('fs')
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected
 let win
 
-function createWindow () {
-  // Create the browser window.
-  win = new BrowserWindow({width: 1024, height:768, backgroundColor: '#000'})
+var pipeline_args    = [{}]
+var pipeline_results = []
+var current_module   = 0
 
-  // and load the index.html of the app.
-  win.loadURL('file:///'+ __dirname + '/index.html')
-  console.log('file:///'+ __dirname + '/index.html')
 
-  // Open the DevTools.
-  //win.webContents.openDevTools()
+function initial() {
+    /**
+     * Desc: Create the initial window, and set the close handler
+     */
+    // Create the browser window.
+    win = new BrowserWindow({width: 1024, height:768, backgroundColor: '#000'})
 
-  // Emitted when the window is closed.
-  win.on('closed', () => {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
-    win = null
-  })
+    // and load the index.html of the app.
+    win.loadURL('file:///'+ __dirname + '/module0.html')
+    console.log('loading module0.html')
+
+    // Open the DevTools.
+    //win.webContents.openDevTools()
+
+    // Emitted when the window is closed.
+    win.on('closed', () => {
+        // Dereference the window object, usually you would store windows
+        // in an array if your app supports multi windows, this is the time
+        // when you should delete the corresponding element.
+        win = null
+    })
 }
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
-app.on('ready', createWindow)
+
+function goToModule(module_number) {
+    /**
+     * Desc: Load and render a module page
+     *
+     * Args: 
+     *      module_number (int): module number to load. Also affects which html file is loaded.
+     *
+     * Returns:
+     *      - If there is a problem rendering the page, False.
+     *      - Else, True.
+     */
+
+    if(pipeline_args.length < module_number) {
+        return false;
+    }
+    
+    // Load the html
+    win.loadURL('file:///' + __dirname + '/module' + Integer.toString(module_number))
+
+    return true;
+}
+
+
+function execPipeline(cmd, args, callback) {
+    /**
+     * Desc: Execute a pipeline command with some arguments.
+     *
+     * Args:
+     *      cmd (string): name of the pipeline script to call
+     *      args (JSON): JSON object of what to throw at the command
+     *      callback (function (res)): callback function to get result, see Returns
+     *
+     * Returns:
+     *      - If pipeline returns an error string, return the error string
+     *      - Else, return null
+     */
+    args_json = JSON.parse(args)
+   
+    pipeline_args[current_module] = args_json
+
+    fs.writeFile(__dirname + 'args.json', args_json.toString())
+
+    result = pipeline.pipeline(cmd, __dirname + 'args.json')
+
+    child_process.exec(__dirname + '/lib/pipeline/' + cmd + 'args.json', (error, stdout, stderr) => {
+        if(!stdout || stdout == '') {
+            callback(stdout)
+
+        } else {
+            // Read back in file
+            fs.readFile(__dirname + 'args.json', 'utf-8', (err, data) => {
+                if(err) {
+                    console.log('Error reading json args file:', err)
+                    callback('Error reading json args file')
+                }
+
+                pipeline_results[current_module] = JSON.parse(result)
+                callback(null)
+            })
+        }
+    })
+}
+
+
+/* CORE WINDOW EVENTS */
+
+app.on('ready', initial)
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
@@ -42,6 +126,26 @@ app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (win === null) {
-    createWindow()
+    initial()
   }
+})
+
+
+
+/* IPC EVENTS */
+
+// Attempt to load a page
+ipc.on('LOADPAGE', (event, module_number) =>  {
+    if(loadPage(data)) {
+        // Send IPC message with the arguments to the current module
+        win.webContents.send('NEW', JSON.toString(pipeline_args[module_number]))
+    }
+})
+
+// Attempt to execute pipeline with args
+ipc.on('EXECUTE', (event, data) => {
+    result = execPipeline(data[0], data[1], (result) => {
+        pipeline_results[pipeline_current] = result;
+        event.sender.send('EXECUTE', result);
+    });
 })

--- a/main.js
+++ b/main.js
@@ -125,7 +125,7 @@ app.on('window-all-closed', () => {
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (win === null) {;
+  if (win === null) {
     initial();
   }
 });


### PR DESCRIPTION
Refactored `main,js` to work with the new async backend spec.

`main.js` will now communicate with the front end GUI's render process through IPC messages, and facilitate pipeline commands and page switches.