### PR TITLE
Fix PCR salt inputs not being populated on window bootstrap

### DIFF
--- a/main.js
+++ b/main.js
@@ -107,6 +107,10 @@ function goToModule(module_number) {
         });
     }
 
+    if(module_number == 1) {
+        return true;
+    }
+
     if(!visited_modules[module_number-1]['executed']){
         return false;
     }

--- a/src/js/module1.js
+++ b/src/js/module1.js
@@ -82,6 +82,12 @@ class Module1 {
             }
         }
 
+        // Init PCR
+        pcr_salts_inputs[0].value = this.pcr_salts['Na'];
+        pcr_salts_inputs[1].value = this.pcr_salts['K'];
+        pcr_salts_inputs[2].value = this.pcr_salts['Tris'];
+        pcr_salts_inputs[3].value = this.pcr_salts['Mg'];
+        pcr_salts_inputs[4].value = this.pcr_salts['dNTPs'];
     }
 
     /**


### PR DESCRIPTION
populate pcr salts inputs even if there is no previous state