### PR TITLE
Add Default Values Input

### DIFF
--- a/src/html/module1.html
+++ b/src/html/module1.html
@@ -102,6 +102,26 @@
           </tr>
         </table>
 
+        <h1>DEFAULT VALUES</h1>
+        <table class="input_table">
+            <tbody>
+                <tr>
+                    <td>
+                        <div>Target Start:</div><input type="number" id="default_target_start" class="target_start">
+                    </td>
+                    <td>
+                        <div>Target End:</div><input type="number" id="default_target_end" class="target_end">
+                    </td>
+                    <td>
+                        <div>Min Length:</div><input type="number" id="default_min_length" class="length_min">
+                    </td>
+                    <td>
+                        <div>Max Length:</div><input type="number" id="default_max_length" class="length_max">
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
         <input type="submit" id="manual_submit" class="input">
       </div>
 

--- a/src/js/module1.js
+++ b/src/js/module1.js
@@ -26,6 +26,10 @@ const bulk_upload = document.getElementById('fasta_file_upload');
 const module_3 = document.getElementById('module3');
 const module_4 = document.getElementById('module4');
 const submit = document.getElementById('nextModule');
+const default_target_start = document.getElementById('default_target_start');
+const default_target_end = document.getElementById('default_target_end');
+const default_min_length = document.getElementById('default_min_length');
+const default_max_length = document.getElementById('default_max_length');
 
 
 /**
@@ -329,6 +333,24 @@ function removeTargetRegionIdentifier(identifier) {
  * @return false identifier was not added
  */
 function addNewTargetRegionIdentifier(identifier_label, sequence, target_start=null, target_end=null, min_length=null, max_length=null) {
+    // For all null values, replace with the values in the defaults section
+    if(!target_start) {
+        target_start = parseInt(default_target_start.value);
+    }
+
+    if(!target_end) {
+        target_end = parseInt(default_target_end.value);
+    }
+
+    if(!min_length) {
+        min_length = parseInt(default_min_length.value);
+    }
+    
+    if(!max_length) {
+        max_length = parseInt(default_max_length.value);
+    }
+    
+    // Add the data to the Module1 class instance. If there's a problem (eg label already exists), abort
     if(!state.addTargetRegionIdentifier(identifier_label, sequence, target_start, target_end, min_length, max_length)) {
         return false;
     }


### PR DESCRIPTION
The target region identifier inputs now support the addition of default values, editable by a new UI element. When adding a new target region, if no value is supplied for any of the four available inputs (min/max length, and target start/end), the value from the defaults UI element is copied and used instead.